### PR TITLE
PIMOB-XXX: exclude unsupported archs through podspec

### DIFF
--- a/Checkout3DS.podspec
+++ b/Checkout3DS.podspec
@@ -33,5 +33,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386 arm64'
   }
 
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386 arm64' }
+  s.pod_target_xcconfig = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386 arm64',
+    'VALID_ARCHS' => 'arm64 x86_64'
+  }
 end


### PR DESCRIPTION
## Changes

- Exclude i386 and arm64 simulator builds from pods project and app